### PR TITLE
[nodeinfoprovider] Improve node info initialization

### DIFF
--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -398,8 +398,14 @@ Poco::JSON::Array Database::ConvertCpuInfoToJSON(const Array<CPUInfo>& cpuInfo)
         pocoItem.set("numCores", srcItem.mNumCores);
         pocoItem.set("numThreads", srcItem.mNumThreads);
         pocoItem.set("arch", srcItem.mArch.CStr());
-        pocoItem.set("archFamily", srcItem.mArchFamily.CStr());
-        pocoItem.set("maxDMIPS", srcItem.mMaxDMIPS);
+
+        if (srcItem.mArchFamily.HasValue()) {
+            pocoItem.set("archFamily", srcItem.mArchFamily->CStr());
+        }
+
+        if (srcItem.mMaxDMIPS.HasValue()) {
+            pocoItem.set("maxDMIPS", *srcItem.mMaxDMIPS);
+        }
 
         dst.add(pocoItem);
     }
@@ -421,8 +427,14 @@ Error Database::ConvertCpuInfoFromJSON(const Poco::JSON::Array& src, Array<CPUIn
         dstItem.mNumCores   = cpuInfo->getValue<size_t>("numCores");
         dstItem.mNumThreads = cpuInfo->getValue<size_t>("numThreads");
         dstItem.mArch       = cpuInfo->getValue<std::string>("arch").c_str();
-        dstItem.mArchFamily = cpuInfo->getValue<std::string>("archFamily").c_str();
-        dstItem.mMaxDMIPS   = cpuInfo->getValue<uint64_t>("maxDMIPS");
+
+        if (cpuInfo->has("archFamily")) {
+            dstItem.mArchFamily.SetValue(cpuInfo->getValue<std::string>("archFamily").c_str());
+        }
+
+        if (cpuInfo->has("maxDMIPS")) {
+            dstItem.mMaxDMIPS.SetValue(cpuInfo->getValue<uint64_t>("maxDMIPS"));
+        }
 
         auto err = dst.PushBack(dstItem);
         if (!err.IsNone()) {

--- a/src/nodeinfoprovider/nodeinfoprovider.cpp
+++ b/src/nodeinfoprovider/nodeinfoprovider.cpp
@@ -225,7 +225,7 @@ Error NodeInfoProvider::InitAtrributesInfo(const iam::config::NodeInfoConfig& co
 Error NodeInfoProvider::InitPartitionInfo(const iam::config::NodeInfoConfig& config)
 {
     for (const auto& partition : config.mPartitions) {
-        PartitionInfo partitionInfo;
+        PartitionInfo partitionInfo = {};
 
         partitionInfo.mName = partition.mName.c_str();
         partitionInfo.mPath = partition.mPath.c_str();

--- a/src/nodeinfoprovider/nodeinfoprovider.hpp
+++ b/src/nodeinfoprovider/nodeinfoprovider.hpp
@@ -64,6 +64,7 @@ public:
     Error UnsubscribeNodeStatusChanged(iam::nodeinfoprovider::NodeStatusObserverItf& observer) override;
 
 private:
+    Error InitOSType(const iam::config::NodeInfoConfig& config);
     Error InitAtrributesInfo(const iam::config::NodeInfoConfig& config);
     Error InitPartitionInfo(const iam::config::NodeInfoConfig& config);
     Error NotifyNodeStatusChanged();

--- a/tests/database/database_test.cpp
+++ b/tests/database/database_test.cpp
@@ -35,7 +35,7 @@ CPUInfo CreateCPUInfo()
     cpuInfo.mNumCores   = 4;
     cpuInfo.mNumThreads = 4;
     cpuInfo.mArch       = "GenuineIntel";
-    cpuInfo.mArchFamily = "6";
+    cpuInfo.mArchFamily.SetValue("6");
 
     return cpuInfo;
 }

--- a/tests/iamclient/iamclient_test.cpp
+++ b/tests/iamclient/iamclient_test.cpp
@@ -89,7 +89,7 @@ CPUInfo CreateCPUInfo()
     cpuInfo.mNumCores   = 4;
     cpuInfo.mNumThreads = 4;
     cpuInfo.mArch       = "GenuineIntel";
-    cpuInfo.mArchFamily = "6";
+    cpuInfo.mArchFamily.SetValue("6");
 
     return cpuInfo;
 }


### PR DESCRIPTION
After changes RPI node info looks like:

```
    "cpuInfo": [
        {
            "arch": "aarch64",
            "archFamily": "",
            "maxDMIPS": 0,
            "modelName": "",
            "numCores": 1,
            "numThreads": 1
        }
    ],
    "osType": "Linux",
```